### PR TITLE
[repo-assist] Add scripts/check-assets.js — HTML asset-reference validation utility

### DIFF
--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * check-assets.js — verify that all local asset references in docs/index.html
+ * resolve to real files on disk. Exits with code 1 if any are missing.
+ *
+ * Usage: node scripts/check-assets.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HTML_FILE = path.resolve(__dirname, '..', 'docs', 'index.html');
+const HTML_DIR  = path.dirname(HTML_FILE);
+
+const html = fs.readFileSync(HTML_FILE, 'utf8');
+
+// Find all href and src attribute values
+const ATTR_RE = /(?:href|src)="([^"]+)"/g;
+let match;
+const missing = [];
+
+while ((match = ATTR_RE.exec(html)) !== null) {
+  const ref = match[1];
+  // Skip absolute and protocol-relative URLs
+  if (/^(?:[a-z][a-z0-9+\-.]*:)?\/\//i.test(ref) || /^[a-z][a-z0-9+\-.]*:/i.test(ref)) {
+    continue;
+  }
+  const resolved = path.resolve(HTML_DIR, ref);
+  if (!fs.existsSync(resolved)) {
+    missing.push({ ref, resolved });
+  }
+}
+
+if (missing.length === 0) {
+  console.log('✅ All asset references in docs/index.html resolve OK.');
+  process.exit(0);
+} else {
+  console.error(`❌ ${missing.length} broken asset reference(s) in docs/index.html:`);
+  for (const { ref, resolved } of missing) {
+    console.error(`  ${ref}  →  ${resolved}`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
🤖 *This PR was created by Repo Assist, an automated AI assistant.*

## Summary

Adds `scripts/check-assets.js`, a zero-dependency Node.js utility that validates all local `href`/`src` references in `docs/index.html` against the filesystem. Broken asset references (e.g. a renamed `game.js` or deleted `styles.css`) would otherwise pass the existing syntax-only CI check and only surface as a blank screen at runtime.

## Why now?

The full CI upgrade patch (Node 20 → 22 + integrating this script as a CI step) is blocked pending `workflows` permission — see issue #45 for manual-apply instructions. This PR delivers the script itself as a standalone utility that can:
- Be run manually: `node scripts/check-assets.js`
- Be merged immediately without any permission elevation
- Be wired into CI later with a simple `run: node scripts/check-assets.js` step

## What the script does

- Parses `docs/index.html` and collects all `href`/`src` attribute values
- Skips absolute and protocol-relative URLs
- Resolves each local reference relative to `docs/` and checks `fs.existsSync`
- Exits 0 if all references are found; exits 1 (with details) if any are missing
- Zero new runtime or dev dependencies

## Test Status

✅ `node scripts/check-assets.js` — both asset references (`./styles.css`, `./game.js`) verified OK  
✅ `node --check docs/game.js` — existing syntax check passes  
✅ No new dependencies introduced




> Generated by 🌈 Repo Assist, see [workflow run](https://github.com/harrywat/bubblescan/actions/runs/27403668566). [Learn more](https://github.com/githubnext/agentics/blob/main/docs/repo-assist.md).
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/repo-assist.md@e15e57b40918dbca11b350c55d02ab61934afa75
```
</details>


<!-- gh-aw-agentic-workflow: Repo Assist, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 27403668566, workflow_id: repo-assist, run: https://github.com/harrywat/bubblescan/actions/runs/27403668566 -->

<!-- gh-aw-workflow-id: repo-assist -->
<!-- gh-aw-workflow-call-id: harrywat/bubblescan/repo-assist -->